### PR TITLE
Reconfigure development config for Mailcatcher and remove Sendgrid items

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,7 @@ class UsersController < ApplicationController
   def create
     user = User.create(user_params)
     if user.save
+      ActivationMailer.activation_email(user).deliver_now
       session[:user_id] = user.id
       redirect_to dashboard_path
     else

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,6 +40,7 @@ Rails.application.configure do
   # Mailcatcher setup
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = { :address => "localhost", :port => 1025 }
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
@@ -64,13 +65,4 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-
-  config.action_mailer.smtp_settings = {
-      address:        "smtp.sendgrid.net",
-      port:           587,
-      domain:         "http://localhost:3000",
-      authentication: :plain,
-      user_name:      'apikey',
-      password:       ENV['SENDGRID_API_KEY']
-}
 end

--- a/spec/features/vistors/visitor_can_register_spec.rb
+++ b/spec/features/vistors/visitor_can_register_spec.rb
@@ -32,6 +32,8 @@ describe 'vister can create an account', :js, :vcr do
     expect(page).to have_content(first_name)
     expect(page).to have_content(last_name)
 
+    expect(ActionMailer::Base.deliveries.length).to eq(1)
+
     expect(page).to have_content("This account has not yet been activated. Please check your email.")
 
     expect(page).to_not have_content('Sign In')


### PR DESCRIPTION
Test results:
```
Finished in 31.06 seconds (files took 3.34 seconds to load)
72 examples, 0 failures

Coverage report generated for RSpec to /Users/dframpton/turing/3module/projects/brownfield-of-dreams/coverage. 265 / 321 LOC (82.55%) covered.
```