### PR TITLE
User can send email invitation to GitHub user

### DIFF
--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -3,14 +3,14 @@ class InviteController < ApplicationController
   end
 
   def create
-    token = current_user.token || ENV['GITHUB_TOKEN']
-    data = GithubService.github_user_data_by_name(params[:github_handle], token)
+    token = current_user.github_token || ENV['GITHUB_TOKEN']
+    data = GithubService.new.github_user_data_by_name(params[:github_handle], token)
     if data['email']
-      # mailer call, send user and invitee
-      # flash success message
-    # else
-      # flash error message
-    # end
+      InviteMailer.send_invite(current_user, data).deliver_now
+      flash[:success] = 'Successfully sent invite!'
+    else
+      flash[:error] = "The Github user you selected doesn't have an email address associated with their account."
+    end
     redirect_to '/dashboard'
   end
 end

--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -1,0 +1,16 @@
+class InviteController < ApplicationController
+  def new
+  end
+
+  def create
+    token = current_user.token || ENV['GITHUB_TOKEN']
+    data = GithubService.github_user_data_by_name(params[:github_handle], token)
+    if data['email']
+      # mailer call, send user and invitee
+      # flash success message
+    # else
+      # flash error message
+    # end
+    redirect_to '/dashboard'
+  end
+end

--- a/app/mailers/invite_mailer.rb
+++ b/app/mailers/invite_mailer.rb
@@ -1,0 +1,2 @@
+class InviteMailer < ApplicationMailer
+end

--- a/app/mailers/invite_mailer.rb
+++ b/app/mailers/invite_mailer.rb
@@ -1,2 +1,7 @@
 class InviteMailer < ApplicationMailer
+  def send_invite(user, invitee_data)
+    @user = user
+    @invitee_data = invitee_data
+    mail(to: @invitee_data['email'], subject: "You're invited to VideoField!")
+  end
 end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -17,6 +17,10 @@ class GithubService
     end
   end
 
+  def github_user_data_by_name(github_handle, token)
+    get_json("users/#{github_handle}", token).slice('name', 'email')
+  end
+
   private
 
     def connection

--- a/app/views/invite/new.html.erb
+++ b/app/views/invite/new.html.erb
@@ -1,0 +1,5 @@
+<%= form_tag '/invite' do %>
+  <%= label_tag :github_handle, 'Github Handle' %>
+  <%= text_field_tag :github_handle %>
+  <%= submit_tag 'Send Invite' %>
+<% end %>

--- a/app/views/invite_mailer/send_invite.html.erb
+++ b/app/views/invite_mailer/send_invite.html.erb
@@ -1,0 +1,3 @@
+Hello <%= @invitee_data['name'] %>,
+
+<%= @user.name %> has invited you to join VideoField. You can create an account <%= link_to 'here', '/register' %>.

--- a/app/views/invite_mailer/send_invite.html.erb
+++ b/app/views/invite_mailer/send_invite.html.erb
@@ -1,3 +1,3 @@
 Hello <%= @invitee_data['name'] %>,
 
-<%= @user.name %> has invited you to join VideoField. You can create an account <%= link_to 'here', '/register' %>.
+<%= @user.name %> has invited you to join VideoField. You can create an account <%= link_to 'here', register_url %>.

--- a/app/views/invite_mailer/send_invite.text.erb
+++ b/app/views/invite_mailer/send_invite.text.erb
@@ -1,0 +1,3 @@
+Hello <%= @invitee_data['name'] %>,
+
+<%= @user.name %> has invited you to join VideoField. You can create an account <%= link_to 'here', '/register' %>.

--- a/app/views/invite_mailer/send_invite.text.erb
+++ b/app/views/invite_mailer/send_invite.text.erb
@@ -1,3 +1,3 @@
 Hello <%= @invitee_data['name'] %>,
 
-<%= @user.name %> has invited you to join VideoField. You can create an account <%= link_to 'here', '/register' %>.
+<%= @user.name %> has invited you to join VideoField. You can create an account <%= link_to 'here', register_url %>.

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,6 +10,10 @@
                 '/auth/github',
                 class: 'link-button' unless @user.github_token %>
 
+  <%= link_to 'Send an Invite',
+                '/invite',
+                class: 'link-button' %>
+
   <%= button_to 'Disconnect GitHub Account',
                 "/users/#{@user.id}",
                 :method => :patch if @user.github_token %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,4 +52,5 @@ Rails.application.routes.draw do
   resources :friendships, only: [:create, :destroy]
 
   get '/invite', to: 'invite#new'
+  post '/invite', to: 'invite#create'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,4 +51,5 @@ Rails.application.routes.draw do
 
   resources :friendships, only: [:create, :destroy]
 
+  get '/invite', to: 'invite#new'
 end

--- a/spec/features/user/user_can_invite_github_users_spec.rb
+++ b/spec/features/user/user_can_invite_github_users_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe 'As a registered user' do
   before(:each) do
     @user = create(:user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
   end
 
   describe 'When I visit /dashboard and click "Send an Invite"' do

--- a/spec/features/user/user_can_invite_github_users_spec.rb
+++ b/spec/features/user/user_can_invite_github_users_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe 'As a registered user' do
     describe 'And when I fill in "Github Handle" with valid username of person with public email and click "Send Invite"' do
       before(:each) do
         fill_in 'Github Handle', with: 'DanielEFrampton'
+
+        click_on 'Send Invite'
       end
 
       it 'Then I should be on /dashboard' do
@@ -34,6 +36,8 @@ RSpec.describe 'As a registered user' do
     describe 'And when I fill in "Github Handle" with valid username of person with public email and click "Send Invite"' do
       before(:each) do
         fill_in 'Github Handle', with: 'mtsimon'
+
+        click_on 'Send Invite'
       end
 
       it 'Then I should be on /dashboard' do

--- a/spec/features/user/user_can_invite_github_users_spec.rb
+++ b/spec/features/user/user_can_invite_github_users_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'As a registered user' do
+RSpec.describe 'As a registered user', :vcr  do
   before(:each) do
     @user = create(:user)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
@@ -13,17 +13,37 @@ RSpec.describe 'As a registered user' do
       click_on 'Send an Invite'
     end
 
-    it 'an email should be sent' do
-      expect(ActionMailer::Base.deliveries.length).to eq(1)
-    end
-
     it 'Then I should be on /invite' do
       expect(current_path).to eq('/invite')
     end
 
-    describe 'And when I fill in "Github Handle" with valid username of person with public email and click "Send Invite"', :vcr do
+    describe 'And when I fill in "Github Handle" with valid username of person with public email and click "Send Invite"' do
       before(:each) do
         fill_in 'Github Handle', with: 'DanielEFrampton'
+
+        click_on 'Send Invite'
+      end
+
+      it 'an email should be sent' do
+        expect(ActionMailer::Base.deliveries.length).to eq(1)
+      end
+
+      it 'Then I should be on /dashboard' do
+        expect(current_path).to eq('/dashboard')
+      end
+
+      it 'And I should see a message that says "Successfully sent invite!"' do
+        expect(page).to have_content("Successfully sent invite!")
+      end
+
+      after(:each) do
+        ActionMailer::Base.deliveries.clear
+      end
+    end
+
+    describe 'And when I fill in "Github Handle" with valid username of person without public email and click "Send Invite"' do
+      before(:each) do
+        fill_in 'Github Handle', with: 'mtsimon'
 
         click_on 'Send Invite'
       end
@@ -36,24 +56,12 @@ RSpec.describe 'As a registered user' do
         expect(current_path).to eq('/dashboard')
       end
 
-      it 'And I should see a message that says "Successfully sent invite!"' do
-        expect(page).to have_content("Successfully sent invite!")
-      end
-    end
-
-    describe 'And when I fill in "Github Handle" with valid username of person with public email and click "Send Invite"', :vcr do
-      before(:each) do
-        fill_in 'Github Handle', with: 'mtsimon'
-
-        click_on 'Send Invite'
-      end
-
-      it 'Then I should be on /dashboard' do
-        expect(current_path).to eq('/dashboard')
-      end
-
       it 'I should see a message that says "The Github user you selected doesn\'t have an email address associated with their account."' do
         expect(page).to have_content("The Github user you selected doesn't have an email address associated with their account.")
+      end
+
+      after(:each) do
+        ActionMailer::Base.deliveries.clear
       end
     end
   end

--- a/spec/features/user/user_can_invite_github_users_spec.rb
+++ b/spec/features/user/user_can_invite_github_users_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe 'As a registered user' do
+  before(:each) do
+    @user = create(:user)
+  end
+
+  describe 'When I visit /dashboard and click "Send an Invite"' do
+    before(:each) do
+      visit '/dashboard'
+
+      click_on 'Send an Invite'
+    end
+
+    it 'Then I should be on /invite' do
+      expect(current_path).to eq('/invite')
+    end
+
+    describe 'And when I fill in "Github Handle" with valid username of person with public email and click "Send Invite"' do
+      before(:each) do
+        fill_in 'Github Handle', with: 'DanielEFrampton'
+      end
+
+      it 'Then I should be on /dashboard' do
+        expect(current_path).to eq('/dashboard')
+      end
+
+      it 'And I should see a message that says "Successfully sent invite!"' do
+        expect(page).to have_content("Successfully sent invite!")
+      end
+    end
+
+    describe 'And when I fill in "Github Handle" with valid username of person with public email and click "Send Invite"' do
+      before(:each) do
+        fill_in 'Github Handle', with: 'mtsimon'
+      end
+
+      it 'Then I should be on /dashboard' do
+        expect(current_path).to eq('/dashboard')
+      end
+
+      it 'I should see a message that says "The Github user you selected doesn\'t have an email address associated with their account."' do
+        expect(page).to have_content("The Github user you selected doesn't have an email address associated with their account.")
+      end
+    end
+  end
+end

--- a/spec/features/user/user_can_invite_github_users_spec.rb
+++ b/spec/features/user/user_can_invite_github_users_spec.rb
@@ -13,15 +13,23 @@ RSpec.describe 'As a registered user' do
       click_on 'Send an Invite'
     end
 
+    it 'an email should be sent' do
+      expect(ActionMailer::Base.deliveries.length).to eq(1)
+    end
+
     it 'Then I should be on /invite' do
       expect(current_path).to eq('/invite')
     end
 
-    describe 'And when I fill in "Github Handle" with valid username of person with public email and click "Send Invite"' do
+    describe 'And when I fill in "Github Handle" with valid username of person with public email and click "Send Invite"', :vcr do
       before(:each) do
         fill_in 'Github Handle', with: 'DanielEFrampton'
 
         click_on 'Send Invite'
+      end
+
+      it 'an email should not have be sent' do
+        expect(ActionMailer::Base.deliveries.length).to eq(0)
       end
 
       it 'Then I should be on /dashboard' do
@@ -33,7 +41,7 @@ RSpec.describe 'As a registered user' do
       end
     end
 
-    describe 'And when I fill in "Github Handle" with valid username of person with public email and click "Send Invite"' do
+    describe 'And when I fill in "Github Handle" with valid username of person with public email and click "Send Invite"', :vcr do
       before(:each) do
         fill_in 'Github Handle', with: 'mtsimon'
 

--- a/spec/mailers/invite_mailer_spec.rb
+++ b/spec/mailers/invite_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe InviteMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/invite_mailer_spec.rb
+++ b/spec/mailers/invite_mailer_spec.rb
@@ -1,5 +1,41 @@
 require "rails_helper"
 
 RSpec.describe InviteMailer, type: :mailer do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'send_invite' do
+    before(:each) do
+      @user = create(:user)
+      @invitee_data = { 'name' => 'John Doe', 'email' => 'johndoe@gmail.com' }
+      @email = described_class.send_invite(@user, @invitee_data).deliver_now
+    end
+
+    it 'has a subject line' do
+      expect(@email.subject).to eq("You're invited to VideoField!")
+    end
+
+    it 'was sent to the email of the user who was invited' do
+      expect(@email.to).to eq([@invitee_data['email']])
+    end
+
+    it 'has the from email of the overall site' do
+      expect(@email.from).to eq(['noreply@videofield.io'])
+    end
+
+    describe 'has a body which' do
+      it 'greets the invitee by name' do
+        expect(@email.body.encoded).to have_content('Hello John Doe,')
+      end
+
+      it 'says who the visitor was invited by' do
+        expect(@email.body.encoded).to have_content("#{@user.name} has invited you to join VideoField.")
+      end
+
+      it 'invites user to click link to signup' do
+        expect(@email.body.encoded).to have_content('You can create an account')
+      end
+
+      it 'has a link with full URL of the registration page' do
+        expect(@email.body.encoded).to have_link('here', href: "http://localhost:3000/register")
+      end
+    end
+  end
 end

--- a/spec/mailers/previews/invite_mailer_preview.rb
+++ b/spec/mailers/previews/invite_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/invite_mailer
+class InviteMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -3,6 +3,18 @@ require 'rails_helper'
 feature GithubService do
   feature 'methods' do
     feature 'instance methods' do
+      feature 'github_user_data_by_name' do
+        scenario 'returns user name and email for GH user with given username', :vcr do
+          token = ENV['GITHUB_TOKEN']
+
+          expected = {'name' => 'Daniel Frampton',
+                      'email' => 'daniel.e.frampton@gmail.com'}
+
+          actual = GithubService.new.github_user_data_by_name('DanielEFrampton', token)
+          expect(actual).to eq(expected)
+        end
+      end
+
       feature 'user_repos' do
         scenario "returns repo objects for first five repos associated with user's github token", :vcr do
           token = ENV['GITHUB_TOKEN']


### PR DESCRIPTION
Resolves #6. 

Test results:
```
Finished in 9.92 seconds (files took 1.53 seconds to load)
85 examples, 0 failures

Coverage report generated for RSpec to /Users/dframpton/turing/3module/projects/brownfield-of-dreams/coverage. 275 / 331 LOC (83.08%) covered.
```