### PR TITLE
Restore bookmark fix

### DIFF
--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -2,9 +2,9 @@ class Tutorial < ApplicationRecord
   has_many :videos, -> { order(position: :ASC) }, dependent: :destroy
   acts_as_taggable_on :tags, :tag_list
   accepts_nested_attributes_for :videos
-  scope :non_classroom, -> {where classroom: false}
+  scope :non_classroom, -> { where classroom: false }
 
-  def has_videos?
+  def videos?
     videos.any?
   end
 end

--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -16,17 +16,15 @@
     <% end %>
   </ul>
 </div>
-<% if @facade.has_videos? %>
+<% if @facade.videos? %>
   <div class="col col-8">
     <div class="title-bookmark">
       <h3><%= @facade.current_video.title %></h3>
-      <div class="bookmarks-btn">
-        <% if current_user %>
-        <%= button_to "Bookmark", user_videos_path(video_id: @facade.current_video.id, user_id: current_user.id), method: :post, class: "btn btn-outline mb1 teal" %>
-        <% else %>
-        <%= link_to "Bookmark", login_path, class: "btn btn-outline mb1 teal" %>
-        <% end %>
-      </div>
+      <%= button_to "Bookmark",
+                  user_videos_path(video_id: @facade.current_video.id,
+                                   user_id: @facade.current_user_id),
+                  method: :post,
+                  class: "bookmarks-btn btn btn-outline mb1 teal" %>
     </div>
 
     <div id="player">

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe Tutorial, type: :model do
   end
 
   describe 'instance_methods' do
-    it 'has_videos?' do
+    it 'videos?' do
       tutorial_1 = create :tutorial
       tutorial_2 = create :tutorial
       create :video, tutorial: tutorial_1
 
-      expect(tutorial_1.has_videos?).to be true 
-      expect(tutorial_2.has_videos?).to be false
+      expect(tutorial_1.videos?).to be true 
+      expect(tutorial_2.videos?).to be false
     end
   end
 end


### PR DESCRIPTION
Restores behavior from "visitor cannot bookmark" branch after mistake when resolving merge conflict.
Brings Rubocop violations back down to 0.

Rubocop:
```
Inspecting 45 files
.............................................

45 files inspected, no offenses detected
```

Test results:
```
Finished in 10.44 seconds (files took 3.47 seconds to load)
94 examples, 0 failures

Coverage report generated for RSpec to /Users/dframpton/turing/3module/projects/brownfield-of-dreams/coverage. 298 / 351 LOC (84.9%) covered.
```